### PR TITLE
Add heroku build script

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,5 +37,6 @@
   },
   "engines": {
     "node": "^10.15.3"
-  }
+  },
+  "heroku-run-build-script": true
 }


### PR DESCRIPTION
Add `heroku-run-build-script: true` to all repos as part of new security requirements. If you have `heroku-postbuild` command then that will need to go on to your `build` script.