### PR TITLE
Add new type of healthcheck for Envoy downstream API calls

### DIFF
--- a/app/api/v1/controllers/healthCheck.js
+++ b/app/api/v1/controllers/healthCheck.js
@@ -1,11 +1,52 @@
 const HealthCheck = require("@financial-times/health-check");
+const AggregateHealthCheck = require("../../../middleware/healthchecks/customHealthChecks");
 
-// Set thresholds here
+// Set vars here
 const envoyEventsThreshold = 10; // 10 events per 5 minutes
 const envoyEventAgeThreshold = 1000; // 1 second
+const timeSpan = '5days'
 
 const health = new HealthCheck({
   checks: [
+    new AggregateHealthCheck({
+      timeSpan: `${timeSpan}`,
+      url1: "https://graphitev2-api.ft.com/render/?from=-5mina&target=summarize(transformNull(internalproducts.heroku.ip-envoy.cron_1.fetch.topicsapi.failure),%20%225mins%22,%20%22sum%22,%20true)&format=json",
+      url2: "https://graphitev2-api.ft.com/render/?from=-5mins&target=summarize(transformNull(internalproducts.heroku.ip-envoy.worker_1.fetch.topicsapi.failure),%20%225mins%22,%20%22sum%22,%20true)&format=json",
+      graphiteKey: process.env.FT_GRAPHITE_KEY,
+			interval: 300000,
+			id: 'aggregate-topicsapi-fetch-failures',
+			name: 'API calls to Topics API failed',
+			severity: 1,
+			businessImpact: 'There have been failed API calls to the Topics API.',
+			technicalSummary: 'There have been failed API calls to the Topics API.',
+			panicGuide: 'Check why there have been failed API calls to the Topics API.'
+		}),
+    new AggregateHealthCheck({
+      timeSpan: `${timeSpan}`,
+      url1: `https://graphitev2-api.ft.com/render/?from=-${timeSpan}&target=summarize(transformNull(internalproducts.heroku.ip-envoy.cron_1.fetch.scs.failure),%20%22${timeSpan}%22,%20%22sum%22,%20true)&format=json`,
+      url2: `https://graphitev2-api.ft.com/render/?from=-${timeSpan}&target=summarize(transformNull(internalproducts.heroku.ip-envoy.worker_1.fetch.scs.failure),%20%22${timeSpan}%22,%20%22sum%22,%20true)&format=json`,
+      graphiteKey: process.env.FT_GRAPHITE_KEY,
+			interval: 300000,
+			id: `aggregate-scs-fetch-failures`,
+			name: `API calls to scs failed`,
+			severity: 1,
+			businessImpact: `There have been failed API calls to the scs API.`,
+			technicalSummary: `There have been failed API calls to the scs API.`,
+			panicGuide: `Check why there have been failed API calls to the scs API.`
+		}),
+    new AggregateHealthCheck({
+      timeSpan: `${timeSpan}`,
+      url1: `https://graphitev2-api.ft.com/render/?from=-${timeSpan}&target=summarize(transformNull(internalproducts.heroku.ip-envoy.cron_1.fetch.userslist.failure),%20%22${timeSpan}%22,%20%22sum%22,%20true)&format=json`,
+      url2: `https://graphitev2-api.ft.com/render/?from=-${timeSpan}&target=summarize(transformNull(internalproducts.heroku.ip-envoy.worker_1.fetch.userslist.failure),%20%22${timeSpan}%22,%20%22sum%22,%20true)&format=json`,
+      graphiteKey: process.env.FT_GRAPHITE_KEY,
+			interval: 300000,
+			id: 'aggregate-userslist-fetch-failures',
+			name: 'API calls to Users List failed',
+			severity: 1,
+			businessImpact: 'There have been failed API calls to the User\'s List API.',
+			technicalSummary: 'There have been failed API calls to the User\'s List API.',
+			panicGuide: 'Check why there have been failed API calls to the User\'s List API.'
+		}),
     {
       type: "graphite-threshold",
       url:
@@ -36,36 +77,36 @@ const health = new HealthCheck({
       technicalSummary: `The age of events in the queue has risen above the specified threshold of ${envoyEventAgeThreshold}. This might indicate an issue and should be monitored.`,
       panicGuide: "Inspect RabbitMQ and Spoor API to see if anything is amiss."
     },
-    {
-      type: "graphite-threshold",
-      url:
-        "https://graphitev2-api.ft.com/render/?from=-5minutes&target=summarize(transformNull(internalproducts.heroku.ip-envoy.cron_1.cron.treeshake.count),%20%225minutes%22,%20%22max%22,%20true)&format=json",
-      interval: 300000,
-      threshold: 0,
-      direction: "above",
-      graphiteKey: process.env.FT_GRAPHITE_KEY,
-      id: "envoy-cron-treeshake",
-      name: "Envoy stuck entities treeshake count 🌲🥤",
-      severity: 3,
-      businessImpact: `There are entities stuck in an Envoy journey, meaning they may not receive all communications from us.`,
-      technicalSummary: `The cron treeshake function has been triggered. This means that there could be something wrong with the way the journey is running.`,
-      panicGuide: "Please check Envoy to see why entitites are getting stuck."
-    },
-    {
-      type: "graphite-threshold",
-      url:
-        "https://graphitev2-api.ft.com/render/?from=-1minutes&target=summarize(transformNull(internalproducts.heroku.ip-envoy.cron_1.cron.moveentities.run%2C0)%2C%221minutes%22%2C%20%22min%22%2C%20true)&format=json",
-      interval: 300000,
-      threshold: 1,
-      direction: "below",
-      graphiteKey: process.env.FT_GRAPHITE_KEY,
-      id: "envoy-cron-move-entities",
-      name: "Envoy moving entities 🔜 🐢",
-      severity: 3,
-      businessImpact: `If entitites are not moving through an Envoy journey, they may not receive all communications from us.`,
-      technicalSummary: `The cron entity-moving function has stopped running, meaning entities could be getting stuck in an Envoy journey.`,
-      panicGuide: "Please check Envoy to see if entitites are getting stuck."
-    }
+    // {
+    //   type: "graphite-threshold",
+    //   url:
+    //     "https://graphitev2-api.ft.com/render/?from=-5minutes&target=summarize(transformNull(internalproducts.heroku.ip-envoy.cron-anon_1.cron.treeshake.count),%20%225minutes%22,%20%22max%22,%20true)&format=json",
+    //   interval: 300000,
+    //   threshold: 0,
+    //   direction: "above",
+    //   graphiteKey: process.env.FT_GRAPHITE_KEY,
+    //   id: "envoy-cron-treeshake",
+    //   name: "Envoy stuck entities treeshake count 🌲🥤",
+    //   severity: 3,
+    //   businessImpact: `There are entities stuck in an Envoy journey, meaning they may not receive all communications from us.`,
+    //   technicalSummary: `The cron treeshake function has been triggered. This means that there could be something wrong with the way the journey is running.`,
+    //   panicGuide: "Please check Envoy to see why entitites are getting stuck."
+    // },
+    // {
+    //   type: "graphite-threshold",
+    //   url:
+    //     "https://graphitev2-api.ft.com/render/?from=-1minutes&target=summarize(transformNull(internalproducts.heroku.ip-envoy.cron_1.cron.moveentities.run%2C0)%2C%221minutes%22%2C%20%22min%22%2C%20true)&format=json",
+    //   interval: 300000,
+    //   threshold: 1,
+    //   direction: "below",
+    //   graphiteKey: process.env.FT_GRAPHITE_KEY,
+    //   id: "envoy-cron-move-entities",
+    //   name: "Envoy moving entities 🔜 🐢",
+    //   severity: 3,
+    //   businessImpact: `If entitites are not moving through an Envoy journey, they may not receive all communications from us.`,
+    //   technicalSummary: `The cron entity-moving function has stopped running, meaning entities could be getting stuck in an Envoy journey.`,
+    //   panicGuide: "Please check Envoy to see if entitites are getting stuck."
+    // }
   ]
 });
 

--- a/app/api/v1/controllers/healthCheck.js
+++ b/app/api/v1/controllers/healthCheck.js
@@ -4,18 +4,53 @@ const AggregateHealthCheck = require("../../../middleware/healthchecks/customHea
 // Set vars here
 const envoyEventsThreshold = 10; // 10 events per 5 minutes
 const envoyEventAgeThreshold = 1000; // 1 second
-const timeSpan = '5days'
+const timeSpan = '5mins'
 
 const health = new HealthCheck({
   checks: [
     new AggregateHealthCheck({
       timeSpan: `${timeSpan}`,
-      url1: "https://graphitev2-api.ft.com/render/?from=-5mina&target=summarize(transformNull(internalproducts.heroku.ip-envoy.cron_1.fetch.topicsapi.failure),%20%225mins%22,%20%22sum%22,%20true)&format=json",
-      url2: "https://graphitev2-api.ft.com/render/?from=-5mins&target=summarize(transformNull(internalproducts.heroku.ip-envoy.worker_1.fetch.topicsapi.failure),%20%225mins%22,%20%22sum%22,%20true)&format=json",
+      url: `https://graphitev2-api.ft.com/render/?from=-${timeSpan}&target=summarize(transformNull(internalproducts.heroku.ip-envoy.*.fetch.volt.*.failure),%20%22${timeSpan}%22,%20%22sum%22,%20true)&format=json`,
+      graphiteKey: process.env.FT_GRAPHITE_KEY,
+			interval: 300000,
+			id: 'aggregate-volt-fetch-failures',
+			name: 'API calls to Volt',
+			severity: 1,
+			businessImpact: 'There have been failed API calls to Volt DB.',
+			technicalSummary: 'There have been failed API calls to Volt DB.',
+			panicGuide: 'Check why there have been failed API calls to Volt DB.'
+		}),
+    new AggregateHealthCheck({
+      timeSpan: `${timeSpan}`,
+      url: `https://graphitev2-api.ft.com/render/?from=-${timeSpan}&target=summarize(transformNull(internalproducts.heroku.ip-envoy.*.fetch.userrecsapi.failure),%20%22${timeSpan}%22,%20%22sum%22,%20true)&format=json`,
+      graphiteKey: process.env.FT_GRAPHITE_KEY,
+			interval: 300000,
+			id: 'aggregate-userrecsapi-fetch-failures',
+			name: 'API calls to User Recs API',
+			severity: 1,
+			businessImpact: 'There have been failed API calls to the User Recs API.',
+			technicalSummary: 'There have been failed API calls to the User Recs API.',
+			panicGuide: 'Check why there have been failed API calls to the User Recs API.'
+		}),
+    new AggregateHealthCheck({
+      timeSpan: `${timeSpan}`,
+      url: `https://graphitev2-api.ft.com/render/?from=-${timeSpan}&target=summarize(transformNull(internalproducts.heroku.ip-envoy.*.fetch.interceptorsvchost.failure),%20%22${timeSpan}%22,%20%22sum%22,%20true)&format=json`,
+      graphiteKey: process.env.FT_GRAPHITE_KEY,
+			interval: 300000,
+			id: 'aggregate-interceptorsvchost-fetch-failures',
+			name: 'API calls to Interceptor SVC Host',
+			severity: 1,
+			businessImpact: 'There have been failed API calls to the Interceptor SVC Host.',
+			technicalSummary: 'There have been failed API calls to the Interceptor SVC Host.',
+			panicGuide: 'Check why there have been failed API calls to the Interceptor SVC Host.'
+		}),
+    new AggregateHealthCheck({
+      timeSpan: `${timeSpan}`,
+      url: `https://graphitev2-api.ft.com/render/?from=-${timeSpan}&target=summarize(transformNull(internalproducts.heroku.ip-envoy.*.fetch.topicsapi.failure),%20%22${timeSpan}%22,%20%22sum%22,%20true)&format=json`,
       graphiteKey: process.env.FT_GRAPHITE_KEY,
 			interval: 300000,
 			id: 'aggregate-topicsapi-fetch-failures',
-			name: 'API calls to Topics API failed',
+			name: 'API calls to Topics API',
 			severity: 1,
 			businessImpact: 'There have been failed API calls to the Topics API.',
 			technicalSummary: 'There have been failed API calls to the Topics API.',
@@ -23,29 +58,39 @@ const health = new HealthCheck({
 		}),
     new AggregateHealthCheck({
       timeSpan: `${timeSpan}`,
-      url1: `https://graphitev2-api.ft.com/render/?from=-${timeSpan}&target=summarize(transformNull(internalproducts.heroku.ip-envoy.cron_1.fetch.scs.failure),%20%22${timeSpan}%22,%20%22sum%22,%20true)&format=json`,
-      url2: `https://graphitev2-api.ft.com/render/?from=-${timeSpan}&target=summarize(transformNull(internalproducts.heroku.ip-envoy.worker_1.fetch.scs.failure),%20%22${timeSpan}%22,%20%22sum%22,%20true)&format=json`,
+      url: `https://graphitev2-api.ft.com/render/?from=-${timeSpan}&target=summarize(transformNull(internalproducts.heroku.ip-envoy.*.fetch.scs.failure),%20%22${timeSpan}%22,%20%22sum%22,%20true)&format=json`,
       graphiteKey: process.env.FT_GRAPHITE_KEY,
 			interval: 300000,
 			id: `aggregate-scs-fetch-failures`,
-			name: `API calls to scs failed`,
+			name: `API calls to Single Consent Store`,
 			severity: 1,
-			businessImpact: `There have been failed API calls to the scs API.`,
-			technicalSummary: `There have been failed API calls to the scs API.`,
-			panicGuide: `Check why there have been failed API calls to the scs API.`
+			businessImpact: `There have been failed API calls to the Single Consent Store.`,
+			technicalSummary: `There have been failed API calls to the Single Consent Store.`,
+			panicGuide: `Check why there have been failed API calls to the Single Consent Store.`
 		}),
     new AggregateHealthCheck({
       timeSpan: `${timeSpan}`,
-      url1: `https://graphitev2-api.ft.com/render/?from=-${timeSpan}&target=summarize(transformNull(internalproducts.heroku.ip-envoy.cron_1.fetch.userslist.failure),%20%22${timeSpan}%22,%20%22sum%22,%20true)&format=json`,
-      url2: `https://graphitev2-api.ft.com/render/?from=-${timeSpan}&target=summarize(transformNull(internalproducts.heroku.ip-envoy.worker_1.fetch.userslist.failure),%20%22${timeSpan}%22,%20%22sum%22,%20true)&format=json`,
+      url: `https://graphitev2-api.ft.com/render/?from=-${timeSpan}&target=summarize(transformNull(internalproducts.heroku.ip-envoy.*.fetch.userslist.failure),%20%22${timeSpan}%22,%20%22sum%22,%20true)&format=json`,
       graphiteKey: process.env.FT_GRAPHITE_KEY,
 			interval: 300000,
 			id: 'aggregate-userslist-fetch-failures',
-			name: 'API calls to Users List failed',
+			name: 'API calls to Users List',
 			severity: 1,
-			businessImpact: 'There have been failed API calls to the User\'s List API.',
-			technicalSummary: 'There have been failed API calls to the User\'s List API.',
-			panicGuide: 'Check why there have been failed API calls to the User\'s List API.'
+			businessImpact: 'There have been failed API calls to the User\'s List.',
+			technicalSummary: 'There have been failed API calls to the User\'s List.',
+			panicGuide: 'Check why there have been failed API calls to the User\'s List.'
+    }),
+    new AggregateHealthCheck({
+      timeSpan: `${timeSpan}`,
+      url: `https://graphitev2-api.ft.com/render/?from=-${timeSpan}&target=summarize(transformNull(internalproducts.heroku.ip-envoy.*.fetch.userslistsapi.failure),%20%22${timeSpan}%22,%20%22sum%22,%20true)&format=json`,
+      graphiteKey: process.env.FT_GRAPHITE_KEY,
+			interval: 300000,
+			id: 'aggregate-userslistsapi-fetch-failures',
+			name: 'API calls to Users Lists API',
+			severity: 1,
+			businessImpact: 'There have been failed API calls to the User\'s Lists API.',
+			technicalSummary: 'There have been failed API calls to the User\'s Lists API.',
+			panicGuide: 'Check why there have been failed API calls to the User\'s Lists API.'
 		}),
     {
       type: "graphite-threshold",

--- a/app/middleware/healthchecks/customHealthChecks.js
+++ b/app/middleware/healthchecks/customHealthChecks.js
@@ -26,7 +26,6 @@ class AggregateHealthCheck extends HealthCheck.Check {
             // check if response array is null
 
             if (data.length === 0) {
-                console.log('no fails: ' + this.options.url)
                 this.ok = true;
                 this.checkOutput = '';
             }
@@ -40,11 +39,7 @@ class AggregateHealthCheck extends HealthCheck.Check {
                     array.push(object.datapoints[0][0])
                 })
 
-                const sum = (accumulator, currentIndex) => {
-                    return (accumulator + currentIndex);
-                }
-
-                const total = array.reduce(sum)
+                const total = array.reduce((accumulator, currentIndex) => accumulator + currentIndex);
 
                 const average = total / data.length;
 

--- a/app/middleware/healthchecks/customHealthChecks.js
+++ b/app/middleware/healthchecks/customHealthChecks.js
@@ -1,0 +1,102 @@
+const HealthCheck = require("@financial-times/health-check");
+const fetch = require('node-fetch');
+
+class AggregateHealthCheck extends HealthCheck.Check {
+    constructor(options) {
+        super(options);
+        this.url1 = options.url1
+        this.url2 = options.url2
+        this.graphiteKey = options.graphiteKey
+        this.timeSpan = options.timeSpan
+    }
+
+    async run() {
+        try {
+            // make call to both graphite endpoints
+            const response1 = await fetch(this.options.url1, {
+                method: 'GET',
+                headers: { key: this.options.graphiteKey }
+            });
+            const response2 = await fetch(this.options.url2, {
+                method: 'GET',
+                headers: { key: this.options.graphiteKey }
+            });
+
+            if (response1.status !== 200 || response2.status !== 200) {
+                throw new Error('Non-200 response, check what is happening with the Graphite URL');
+            }
+
+            if (response1.status === 200 && response2.status === 200) {
+                // check whether they are null or not (to do later)
+                let reading1 = await response1.json();
+                let reading2 = await response2.json();
+
+                // if both null, return ok healthcheck
+                if (reading1.length === 0 && reading1.length === 0) {
+                    console.log('both are null')
+                    this.ok = true;
+                    this.checkOutput = '';
+                }
+                // if one is null, only return the other
+                else if (reading1.length === 0 || reading2.length === 0) {
+                    console.log('one is null')
+                    if (reading1.length === 0) {
+                        reading2 = reading2[0].datapoints[0][0]
+                        console.log(reading2)
+                        if (reading2 > 0) {
+                            this.ok = false;
+                            this.checkOutput = `${reading2} failed API calls in the last ${this.options.timeSpan}`;
+                        } else {
+                            this.ok = true;
+                            this.checkOutput = '';
+                        }
+                    }
+                    if (reading2.length === 0) {
+                        reading1 = reading1[0].datapoints[0][0]
+                        console.log(reading1)
+                        if (reading1 > 0) {
+                            this.ok = false;
+                            this.checkOutput = `${reading1} failed API calls in the last ${this.options.timeSpan}`;
+                        } else {
+                            this.ok = true;
+                            this.checkOutput = '';
+                        }
+                    }
+                }
+                // if neither are null, average the result
+                else {
+                    console.log('neither are null')
+                    reading1 = reading1[0].datapoints[0][0]
+                    reading2 = reading2[0].datapoints[0][0]
+
+                    console.log(reading1, reading2)
+
+                    function avg(data1, data2) {
+                        return (data1 + data2) / 2
+                    }
+
+                    const average = avg(reading1, reading2);
+
+                    // if the result is above one, set off the healthcheck
+                    if (average > 0) {
+                        this.ok = false;
+                        this.checkOutput = `${average} averaged failed API calls in the last ${this.options.timeSpan}`;
+                    } else {
+                        this.ok = true;
+                        this.checkOutput = '';
+                    }
+                }
+            }
+        }
+        catch (error) {
+            this.log.error({ event: 'Problem with aggregate healthcheck', error: error.toString() });
+            this.ok = false;
+            this.checkOutput = error.toString();
+        }
+        finally {
+            this.lastUpdated = new Date();
+        }
+    }
+}
+
+module.exports = AggregateHealthCheck;

--- a/app/middleware/healthchecks/customHealthChecks.js
+++ b/app/middleware/healthchecks/customHealthChecks.js
@@ -1,0 +1,95 @@
+const HealthCheck = require("@financial-times/health-check");
+const fetch = require('node-fetch');
+
+class AggregateHealthCheck extends HealthCheck.Check {
+    constructor(options) {
+        super(options);
+        this.url1 = options.url1
+        this.url2 = options.url2
+        this.graphiteKey = options.graphiteKey
+        this.timeSpan = options.timeSpan
+    }
+
+    async run() {
+        try {
+            // make call to both graphite endpoints
+            const response1 = await fetch(this.options.url1, {
+                method: 'GET',
+                headers: { key: this.options.graphiteKey }
+            });
+            const response2 = await fetch(this.options.url2, {
+                method: 'GET',
+                headers: { key: this.options.graphiteKey }
+            });
+
+            if (response1.status !== 200 || response2.status !== 200) {
+                throw new Error('Non-200 response, check what is happening with the Graphite URL');
+            }
+
+            if (response1.status === 200 && response2.status === 200) {
+                // check whether they are null or not (to do later)
+                let reading1 = await response1.json();
+                let reading2 = await response2.json();
+
+                // if both null, return ok healthcheck
+                if (reading1.length === 0 && reading1.length === 0) {
+                    this.ok = true;
+                    this.checkOutput = '';
+                }
+                // if one is null, only return the other
+                else if (reading1.length === 0 || reading2.length === 0) {
+                    if (reading1.length === 0) {
+                        reading2 = reading2[0].datapoints[0][0]
+                        if (reading2 > 0) {
+                            this.ok = false;
+                            this.checkOutput = `${reading2} failed API calls in the last ${this.options.timeSpan}`;
+                        } else {
+                            this.ok = true;
+                            this.checkOutput = '';
+                        }
+                    }
+                    if (reading2.length === 0) {
+                        reading1 = reading1[0].datapoints[0][0]
+                        if (reading1 > 0) {
+                            this.ok = false;
+                            this.checkOutput = `${reading1} failed API calls in the last ${this.options.timeSpan}`;
+                        } else {
+                            this.ok = true;
+                            this.checkOutput = '';
+                        }
+                    }
+                }
+                // if neither are null, average the result
+                else {
+                    reading1 = reading1[0].datapoints[0][0]
+                    reading2 = reading2[0].datapoints[0][0]
+
+                    function avg(data1, data2) {
+                        return (data1 + data2) / 2
+                    }
+
+                    const average = avg(reading1, reading2);
+
+                    // if the result is above one, set off the healthcheck
+                    if (average > 0) {
+                        this.ok = false;
+                        this.checkOutput = `${average} averaged failed API calls in the last ${this.options.timeSpan}`;
+                    } else {
+                        this.ok = true;
+                        this.checkOutput = '';
+                    }
+                }
+            }
+        }
+        catch (error) {
+            this.log.error({ event: 'Problem with aggregate healthcheck', error: error.toString() });
+            this.ok = false;
+            this.checkOutput = error.toString();
+        }
+        finally {
+            this.lastUpdated = new Date();
+        }
+    }
+}
+
+module.exports = AggregateHealthCheck;

--- a/package-lock.json
+++ b/package-lock.json
@@ -2269,6 +2269,17 @@
       "requires": {
         "node-fetch": "^1.0.1",
         "whatwg-fetch": ">=0.10.0"
+      },
+      "dependencies": {
+        "node-fetch": {
+          "version": "1.7.3",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
+          "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+          "requires": {
+            "encoding": "^0.1.11",
+            "is-stream": "^1.0.1"
+          }
+        }
       }
     },
     "isstream": {
@@ -2654,13 +2665,9 @@
       "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk="
     },
     "node-fetch": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
-      "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
-      "requires": {
-        "encoding": "^0.1.11",
-        "is-stream": "^1.0.1"
-      }
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.3.0.tgz",
+      "integrity": "sha512-MOd8pV3fxENbryESLgVIeaGKrdl+uaYhCSSVkjeOb/31/njTpcis5aWfdqgNlHIrKOLRbMnfPINPOML2CIFeXA=="
     },
     "nodemon": {
       "version": "1.18.9",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "knex": "^0.15.2",
     "lodash": "^4.17.11",
     "multer": "^1.4.1",
+    "node-fetch": "^2.3.0",
     "pg": "^7.6.0",
     "swagger-jsdoc": "^3.2.6",
     "swagger-ui-express": "^4.0.2",


### PR DESCRIPTION
Now that we have metrics appearing in Graphite for most (all?) our downstream API calls, we want to start monitoring them.

I have written a new custom health check based on the node-health-check docs. Because we make API calls in both `worker_1` and `cron_1`, we want to aggregate the fetch failures across both.

In the custom health check there is some logic to handle the three situations we could run into here:

1. An API call has not failed yet in either `worker_1` or `cron_1`, so we do not yet have a failure metric in Graphite for it:

If there are no failed API calls, that means everything is working fine, so the health check returns 'OK'.

2. An API call has failed in `worker_1` or `cron_1` but not the other, so there is a Graphite metric for one and not the other:

We don't have two failure metrics to average together, so we just return the one failed metric and the health check fails. The health check is sensitive and alerts us for number of failures over 0, i.e. any failures at all.

3. An API call has failed in both `worker_1` or `cron_1`, so we have metrics in Graphite for both:

Based on conversations with @tom-parker I've asked the health check to then average together the number of failures over the specified time period. For now we want to know if any failures are happening, so I've made the health check very sensitive and it will alert us if the failure rate is above 0, i.e. any failures at all.

To test all 3 situations I've added in health checks for our API calls to SCS, user's list, and topics API. Over the past 5 days: 

- SCS has failed on one but not the other
- user's list has failed on both
- topics API has not failed

As demonstrated by this Graphite graph:

<img width="608" alt="Screenshot 2019-03-27 at 11 08 01" src="https://user-images.githubusercontent.com/37520401/55072112-2d731c80-5082-11e9-98da-9480141fe8c5.png">

So we'd expect the health check to be ok for topics, but failing for the other two. It seems to be working as demonstrated here:

<img width="1156" alt="Screenshot 2019-03-27 at 11 11 24" src="https://user-images.githubusercontent.com/37520401/55072123-349a2a80-5082-11e9-92cd-31c1661ccd8f.png">

I know it's an `if` soup right now so any advice on how to make it cleaner is appreciated.