### PR TITLE
Use named parameter binding to prevent sql injection 🐿 v2.12.5

### DIFF
--- a/app/db/sql/entity.js
+++ b/app/db/sql/entity.js
@@ -32,15 +32,14 @@ function deleteFromTrack({ trackId, entities, entityType }) {
 
 async function deleteFromJourney({ journeyName, entities, entityType }) {
    const knex = connect(entityType);
-   const query = `
-   UPDATE core.entity_journey_progression SET 
-   jsondata = jsondata - '${journeyName}'
-   where "entityId" in (${entities.map(e => `'${e}'`).join(', ')})
-   RETURNING "entityId";
-   `;
-   logger.debug('Running query: ' + query);
-   const res = await knex.raw(query);
-   return res;
+
+   return await knex.raw(`
+    UPDATE core.entity_journey_progression SET 
+    jsondata = jsondata - :journeyName
+    where "entityId" = ANY(:entities)
+    RETURNING "entityId";
+   `,
+   { journeyName, entities } );
 }
 
 

--- a/app/db/sql/journey.js
+++ b/app/db/sql/journey.js
@@ -1,12 +1,11 @@
 const { connect } = require("../connect");
 
 async function list(entityType, statusIds = [1, 2, 3, 4, 5]) {
-  const ids = statusIds.join(","); // needed due to knex weirdness
   const knex = connect(entityType);
   const res = await knex.raw(`
     SELECT * from core.journey
-    WHERE "journeyStatusId" IN (${ids})
-  `);
+    WHERE "journeyStatusId" = ANY (:statusIds)
+  `, {statusIds});
   return res.rows;
 }
 
@@ -14,9 +13,9 @@ async function getById(journeyId, entityType) {
   const knex = connect(entityType);
   const res = await knex.raw(`
     SELECT * from core.journey
-    WHERE "journeyId" = ?
+    WHERE "journeyId" = :journeyId
   `,
-  journeyId
+  {journeyId}
   );
   return res.rows[0];
 }


### PR DESCRIPTION
Have not bothered with the v1-only functions, as they'll be ripped out post-migration.