### PR TITLE
Add actions, silos and steps

### DIFF
--- a/app/api/v2/controllers/actionController.js
+++ b/app/api/v2/controllers/actionController.js
@@ -1,0 +1,16 @@
+const core = require("../../../core");
+
+async function list(req, res, next) {
+  try {
+    const actions = await core.action.list({ entityType: "user" });
+    return res.status(200).json({
+      data: actions
+    });
+  } catch (e) {
+    return next(e);
+  }
+}
+
+module.exports = {
+  list
+};

--- a/app/api/v2/controllers/siloController.js
+++ b/app/api/v2/controllers/siloController.js
@@ -1,0 +1,16 @@
+const core = require("../../../core");
+
+async function list(req, res, next) {
+  try {
+    const silos = await core.silo.list("user");
+    return res.status(200).json({
+      data: silos
+    });
+  } catch (e) {
+    return next(e);
+  }
+}
+
+module.exports = {
+  list
+};

--- a/app/api/v2/controllers/siloController.js
+++ b/app/api/v2/controllers/siloController.js
@@ -2,7 +2,8 @@ const core = require("../../../core");
 
 async function list(req, res, next) {
   try {
-    const silos = await core.silo.list("user");
+    const journeyId = req.query.journeyId;
+    const silos = await core.silo.list({ entityType: "user", journeyId });
     return res.status(200).json({
       data: silos
     });

--- a/app/api/v2/controllers/stepController.js
+++ b/app/api/v2/controllers/stepController.js
@@ -1,0 +1,16 @@
+const core = require("../../../core");
+
+async function list(req, res, next) {
+  try {
+    const steps = await core.step.list("user");
+    return res.status(200).json({
+      data: steps
+    });
+  } catch (e) {
+    return next(e);
+  }
+}
+
+module.exports = {
+  list
+};

--- a/app/api/v2/routes/action.js
+++ b/app/api/v2/routes/action.js
@@ -1,0 +1,11 @@
+const express = require("express");
+
+const {
+  list
+} = require("../controllers/actionController");
+
+const router = express.Router();
+
+router.route("/").get(list);
+
+module.exports = router;

--- a/app/api/v2/routes/index.js
+++ b/app/api/v2/routes/index.js
@@ -3,6 +3,7 @@ const express = require("express");
 const journeyRoute = require("./journey");
 const reportRoute = require("./report");
 const entityRoute = require("./entity");
+const actionRoute = require("./action");
 const siloRoute = require("./silo");
 const stepRoute = require("./step");
 
@@ -13,6 +14,7 @@ const router = express.Router();
 router.use("/journey", journeyRoute);
 router.use("/report", reportRoute);
 router.use("/entity", entityRoute);
+router.use("/action", actionRoute);
 router.use("/silo", siloRoute);
 router.use("/step", stepRoute);
 

--- a/app/api/v2/routes/index.js
+++ b/app/api/v2/routes/index.js
@@ -3,6 +3,8 @@ const express = require("express");
 const journeyRoute = require("./journey");
 const reportRoute = require("./report");
 const entityRoute = require("./entity");
+const siloRoute = require("./silo");
+const stepRoute = require("./step");
 
 // Top level router.
 const router = express.Router();
@@ -11,5 +13,7 @@ const router = express.Router();
 router.use("/journey", journeyRoute);
 router.use("/report", reportRoute);
 router.use("/entity", entityRoute);
+router.use("/silo", siloRoute);
+router.use("/step", stepRoute);
 
 module.exports = router;

--- a/app/api/v2/routes/silo.js
+++ b/app/api/v2/routes/silo.js
@@ -1,0 +1,11 @@
+const express = require("express");
+
+const {
+  list
+} = require("../controllers/siloController");
+
+const router = express.Router();
+
+router.route("/").get(list);
+
+module.exports = router;

--- a/app/api/v2/routes/step.js
+++ b/app/api/v2/routes/step.js
@@ -1,0 +1,11 @@
+const express = require("express");
+
+const {
+  list
+} = require("../controllers/stepController");
+
+const router = express.Router();
+
+router.route("/").get(list);
+
+module.exports = router;

--- a/app/core/action.js
+++ b/app/core/action.js
@@ -1,0 +1,9 @@
+const actionSQL = require("../db/sql/action");
+
+async function list(params) {
+  return actionSQL.list(params);
+}
+
+module.exports = {
+  list
+};

--- a/app/core/index.js
+++ b/app/core/index.js
@@ -2,10 +2,14 @@ const track = require("./track");
 const journey = require("./journey");
 const report = require("./report");
 const entity = require("./entity");
+const silo = require("./silo");
+const step = require("./step");
 
 module.exports = {
   track,
   journey,
   report,
-  entity
+  entity,
+  silo,
+  step
 };

--- a/app/core/index.js
+++ b/app/core/index.js
@@ -2,6 +2,7 @@ const track = require("./track");
 const journey = require("./journey");
 const report = require("./report");
 const entity = require("./entity");
+const action = require("./action");
 const silo = require("./silo");
 const step = require("./step");
 
@@ -10,6 +11,7 @@ module.exports = {
   journey,
   report,
   entity,
+  action,
   silo,
   step
 };

--- a/app/core/silo.js
+++ b/app/core/silo.js
@@ -1,0 +1,9 @@
+const siloSQL = require("../db/sql/silo");
+
+async function list(entityType) {
+  return siloSQL.list(entityType);
+}
+
+module.exports = {
+  list
+};

--- a/app/core/silo.js
+++ b/app/core/silo.js
@@ -1,7 +1,7 @@
 const siloSQL = require("../db/sql/silo");
 
-async function list(entityType) {
-  return siloSQL.list(entityType);
+async function list(params) {
+  return siloSQL.list(params);
 }
 
 module.exports = {

--- a/app/core/step.js
+++ b/app/core/step.js
@@ -1,0 +1,9 @@
+const stepSQL = require("../db/sql/step");
+
+async function list(entityType) {
+  return stepSQL.list(entityType);
+}
+
+module.exports = {
+  list
+};

--- a/app/db/sql/action.js
+++ b/app/db/sql/action.js
@@ -1,0 +1,18 @@
+const { connect } = require("../connect");
+
+async function list({ entityType }) {
+  const knex = connect(entityType);
+  let query = `
+    SELECT * from core.action_silo
+    LEFT JOIN core.action
+    ON action_silo."actionId" = action."actionId"
+    LEFT JOIN core."actionType"
+    ON action."actionTypeId" = "actionType"."actionTypeId"
+  `;
+  const res = await knex.raw(query);
+  return res.rows;
+}
+
+module.exports = {
+  list
+};

--- a/app/db/sql/action.js
+++ b/app/db/sql/action.js
@@ -3,11 +3,11 @@ const { connect } = require("../connect");
 async function list({ entityType }) {
   const knex = connect(entityType);
   let query = `
-    SELECT * from core.action_silo
-    LEFT JOIN core.action
-    ON action_silo."actionId" = action."actionId"
-    LEFT JOIN core."actionType"
-    ON action."actionTypeId" = "actionType"."actionTypeId"
+    SELECT * from core.action_silo s
+    LEFT JOIN (SELECT "actionId", "actionTypeId", name as "actionName" from core.action) a
+    ON s."actionId" = a."actionId"
+    LEFT JOIN (SELECT "actionTypeId", name as "actionTypeName" from core."actionType") at
+    ON a."actionTypeId" = at."actionTypeId"
   `;
   const res = await knex.raw(query);
   return res.rows;

--- a/app/db/sql/entity.js
+++ b/app/db/sql/entity.js
@@ -4,17 +4,17 @@ const logger = require('../../logger')
 function getDeletionFn(knex,  trx, trackId, entities) {
   return function(table) {
     return knex.raw(`
-    DELETE FROM ${table}
+    DELETE FROM :table
     WHERE entity_silo_id IN (
       SELECT distinct(entity_silo_id)
       FROM core."entity_silo" es
       INNER JOIN core."silo" s on es."siloId" = s."siloId"
       INNER JOIN core."trackRev" tr ON s."trackRevId" = tr."trackRevId"
       inner join core.track t ON tr."trackId" = t."trackId"
-      WHERE t."trackId" = ${trackId}
-      AND es."entityId" in (${entities.map(e => `'${e}'`).join(', ')})
+      WHERE t."trackId" = :trackId
+      AND es."entityId" = ANY(:entities)
     )
-  `).transacting(trx)
+  `, { table, trackId, entities }).transacting(trx)
   }
 }
 

--- a/app/db/sql/report.js
+++ b/app/db/sql/report.js
@@ -27,15 +27,15 @@ async function getEntityCountForTrackSilos({ trackId, trackName, entityType }) {
     AND tr."deleted" IS NULL
     AND "campaignRev"."deleted" IS NULL `;
   if (trackId) {
-    query += `AND tr."trackRevId" = ${trackId} `;
+    query += `AND tr."trackRevId" = :trackId `;
   } else {
-    query += `AND t."name" = '${trackName}' `;
+    query += `AND t."name" = :trackName `;
   }
   query += `GROUP BY es."siloId", silo."name", silo."descr", t."name", t."descr", st."name", "campaign"."name"
       ORDER BY "campaign"."name", t."name", es."siloId";
   `;
   console.warn(query);
-  const res = await knex.raw(query);
+  const res = await knex.raw(query, { trackId, trackName });
   return res.rows;
 }
 
@@ -69,14 +69,14 @@ async function getVisitedTrackSilosForEntity({
     ON tr."trackRevId" = s."trackRevId"
     INNER JOIN core."track" AS t
     ON t."trackId" = tr."trackRevId"
-      WHERE "entityId" = '${entityId}' `;
+      WHERE "entityId" = :entityId `;
   if (trackId) {
-    query += `AND s."trackRevId" = ${trackId} `;
+    query += `AND s."trackRevId" = :trackId `;
   } else {
-    query += `AND t."name" = '${trackName}' `;
+    query += `AND t."name" = :trackName `;
   }
   query += `ORDER BY "entityId", es."created";`;
-  const res = await knex.raw(query);
+  const res = await knex.raw(query, { entityId, trackId, trackName });
   return res.rows;
 }
 
@@ -88,9 +88,9 @@ async function getEntitiesForSiloCount({ siloId, entityType }) {
     LEFT JOIN core."entity_silo" AS esx
     ON esx."parent_entity_silo_id" = es."entity_silo_id"
     WHERE esx."parent_entity_silo_id" IS NULL
-    AND es."siloId" = ${siloId};
+    AND es."siloId" = :siloId;
   `;
-  const res = await knex.raw(query);
+  const res = await knex.raw(query, { siloId });
   return res.rows[0].count;
 }
 
@@ -102,9 +102,9 @@ async function getEntitiesForSilo({ siloId, entityType, page, size }) {
     LEFT JOIN core."entity_silo" AS esx
     ON esx."parent_entity_silo_id" = es."entity_silo_id"
     WHERE esx."parent_entity_silo_id" IS NULL
-    AND es."siloId" = ${siloId} LIMIT ${size} OFFSET ${page};
+    AND es."siloId" = :siloId LIMIT :size OFFSET :page;
   `;
-  const res = await knex.raw(query);
+  const res = await knex.raw(query, { siloId, size, page });
   return res.rows;
 }
 

--- a/app/db/sql/silo.js
+++ b/app/db/sql/silo.js
@@ -4,6 +4,8 @@ async function list({ entityType, journeyId }) {
   const knex = connect(entityType);
   let query = `
     SELECT * from core.silo
+    LEFT JOIN core."siloType"
+    ON silo."siloTypeId" = "siloType"."siloTypeId"
   `;
   if (journeyId) {
     query += `

--- a/app/db/sql/silo.js
+++ b/app/db/sql/silo.js
@@ -1,10 +1,16 @@
 const { connect } = require("../connect");
 
-async function list(entityType) {
+async function list({ entityType, journeyId }) {
   const knex = connect(entityType);
-  const res = await knex.raw(`
+  let query = `
     SELECT * from core.silo
-  `);
+  `;
+  if (journeyId) {
+    query += `
+      WHERE "journeyId" = ${journeyId}
+    `;
+  }
+  const res = await knex.raw(query);
   return res.rows;
 }
 

--- a/app/db/sql/silo.js
+++ b/app/db/sql/silo.js
@@ -3,9 +3,9 @@ const { connect } = require("../connect");
 async function list({ entityType, journeyId }) {
   const knex = connect(entityType);
   let query = `
-    SELECT * from core.silo
-    LEFT JOIN core."siloType"
-    ON silo."siloTypeId" = "siloType"."siloTypeId"
+    SELECT * from core.silo s
+    LEFT JOIN (SELECT "siloTypeId", name as "siloTypeName" from core."siloType") st
+    ON s."siloTypeId" = st."siloTypeId"
   `;
   if (journeyId) {
     query += `

--- a/app/db/sql/silo.js
+++ b/app/db/sql/silo.js
@@ -1,0 +1,13 @@
+const { connect } = require("../connect");
+
+async function list(entityType) {
+  const knex = connect(entityType);
+  const res = await knex.raw(`
+    SELECT * from core.silo
+  `);
+  return res.rows;
+}
+
+module.exports = {
+  list
+};

--- a/app/db/sql/silo.js
+++ b/app/db/sql/silo.js
@@ -9,10 +9,10 @@ async function list({ entityType, journeyId }) {
   `;
   if (journeyId) {
     query += `
-      WHERE "journeyId" = ${journeyId}
+      WHERE "journeyId" = :journeyId
     `;
   }
-  const res = await knex.raw(query);
+  const res = await knex.raw(query, { journeyId });
   return res.rows;
 }
 

--- a/app/db/sql/step.js
+++ b/app/db/sql/step.js
@@ -1,0 +1,13 @@
+const { connect } = require("../connect");
+
+async function list(entityType) {
+  const knex = connect(entityType);
+  const res = await knex.raw(`
+    SELECT * from core.step
+  `);
+  return res.rows;
+}
+
+module.exports = {
+  list
+};

--- a/app/db/sql/track.js
+++ b/app/db/sql/track.js
@@ -7,8 +7,8 @@ async function list(entityType, statusIds = [1, 2, 3, 4, 5]) {
     SELECT t.*, tr.created FROM "core"."track" t
     INNER JOIN "core"."trackRev" tr
     ON t."trackId" = tr."trackId"
-    WHERE "t"."trackStatusId" IN (${ids})
-  `);
+    WHERE "t"."trackStatusId" IN (:ids)
+  `, { ids });
   return res.rows;
 }
 


### PR DESCRIPTION
This API currently serves journeys, tracks (v1) and entities, as well as a kind of aggregation report. This PR adds actions, silos and steps to the API. This is useful when directly accessing DB isn't practical such as with the Envoy UI.